### PR TITLE
Fix include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+
 main: src/main.cpp src/Game.cpp src/Player.cpp src/Enemy.cpp bin
-	clang++ src/main.cpp src/Game.cpp src/Player.cpp src/Enemy.cpp -lsfml-graphics -lsfml-window -lsfml-system -o bin/main
+	clang++ src/main.cpp src/Game.cpp src/Player.cpp src/Enemy.cpp -lsfml-graphics -lsfml-window -lsfml-system -o bin/main -I./include/
 
 bin: 
 	mkdir -p bin

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1,4 +1,4 @@
-#include "include/Game.hpp"
+#include "Game.hpp"
 
 /* 
     private Functions

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include "include/Game.hpp"
+#include "Game.hpp"
 
 int main() {
     


### PR DESCRIPTION
Compiling (at least on Linux) throws 
`src/main.cpp:2:10: fatal error: 'include/Game.hpp' file not found`
and
`src/Game.cpp:1:10: fatal error: 'include/Game.hpp' file not found`
This PR fixes this by
adding `./include` folder to include list via compiler flag
and making all `#incude` statements reflect that