### PR TITLE
Properly wrap SRC variable in $(), so that 'make' knows it is a variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LFLAGS = -lsfml-graphics -lsfml-window -lsfml-system -lsfml-audio
 
 FLAGS = -o bin/main -I./include/ -std=c++17
 
-main: SRC bin
+main: $(SRC) bin
 	$(CXX) $(SRC) $(LFLAGS) $(FLAGS) 
 
 bin: 


### PR DESCRIPTION
'make' doesn't recognize "SRC" as a variable without wrapping it in "$(...)". (at least on Linux)